### PR TITLE
优化顶部绿色背景的加载

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Page Header -->
-<header class="intro-header" style="background-image: url('{{ site.baseurl }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}')">
+<header class="intro-header" style="background-color:#00955F">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 <!-- Post Header -->
 <style type="text/css">
     header.intro-header{
-        background-image: url('{{ site.baseurl }}/{% if page.header-img %}{{ page.header-img }}{% else %}{{ site.header-img }}{% endif %}')
+        background-color:#00955F
     }
 </style>
 <header class="intro-header" >


### PR DESCRIPTION
如果不打算把这个背景换成别的东西的话，用单纯的背景颜色（background-color）会比原有的图片（background-image）好些，省去加载过程。404、category、tags 页面也使用了图片作为背景，但又引用了默认的 page layout ，没有仔细研究整个框架，所以暂时没有修改它们。